### PR TITLE
Cycle debug

### DIFF
--- a/templates/cycle-builder/README.md
+++ b/templates/cycle-builder/README.md
@@ -41,6 +41,7 @@ The cycle builider expects the following ODB structure to exist:
  0x04000400 | LaBr3 Trigger
  0x08000800 | DESCANT Trigger
  0xC002C002 | Collect Background
+ 0xC001C001 | Collect Data with Beam on
  0xC004C004 | Collect Data with Beam off
  0xC010C010 | Collect Source Data
  0x00020002 | Unassigned Output 2

--- a/templates/cycle-builder/cycle-builder.html
+++ b/templates/cycle-builder/cycle-builder.html
@@ -236,10 +236,10 @@
             window.alert("There doesn't seem to be a valid cycle name set. In the ODB, look in /PPG/Current, and make sure this is set to one of the cycles listed in /PPG/Cycles.")
         }
 
-        for(i=0; i<dataStore.ODB.PPG.Cycles[cycleName].PPGcodes.length; i++){
+        for(i=0; i<dataStore.ODB.PPG.Cycles[cycleName].PPGCodes.length; i++){
         
             addNewCycleStep();
-            loadCycleStep(dataStore.cycle.stepIndex-1, dataStore.ODB.PPG.Cycles[cycleName].PPGcodes[i], dataStore.ODB.PPG.Cycles[cycleName].durations[i]);
+            loadCycleStep(dataStore.cycle.stepIndex-1, dataStore.ODB.PPG.Cycles[cycleName].PPGCodes[i], dataStore.ODB.PPG.Cycles[cycleName].durations[i]);
         }
 
         document.getElementById('cycleName').value = cycleName;

--- a/templates/cycle-builder/cycle-builder.html
+++ b/templates/cycle-builder/cycle-builder.html
@@ -8,6 +8,7 @@
             <label for='cycleName'>Current Displayed Cycle:</label>
             <input type='text' id='cycleName' class='wideText'></input>
             <button class='btn btn-info' onclick='writeNewCycle()'>Save Cycle Definition</button>
+            <button class='btn btn-success' onclick='writeNewCycle(true)'>Save & Apply Cycle Definition</button>
         </div>
 
         <div>
@@ -346,7 +347,7 @@
 
             //or together all actions in this cycle step
             stepCode = 0
-            cycleActions = document.querySelectorAll('input.cycleOption[type="checkbox"]:checked');
+            cycleActions = cycleSteps[i].querySelectorAll('input.cycleOption[type="checkbox"]:checked');
             for(j=0; j<cycleActions.length; j++){
                 stepCode = stepCode | cycleActions[j].value;
             }
@@ -357,8 +358,11 @@
                 cycleDurations += ',';
             }
             cycleStepCodes += stepCode;
-            cycleDurations += parseInt(document.getElementById(stepIndex+'Duration').value, 10) * parseInt(selected(stepIndex+'DurationUnit') , 10)
+            cycleDurations += Math.floor(parseFloat(document.getElementById(stepIndex+'Duration').value, 10) * parseInt(selected(stepIndex+'DurationUnit') , 10))
         }
+
+        console.log(cycleDurations)
+        console.log(cycleStepCodes)
 
         // create the requests
         // different syntax to set one thing versus an array of things...

--- a/templates/cycle-builder/cycle-builder.html
+++ b/templates/cycle-builder/cycle-builder.html
@@ -236,10 +236,10 @@
             window.alert("There doesn't seem to be a valid cycle name set. In the ODB, look in /PPG/Current, and make sure this is set to one of the cycles listed in /PPG/Cycles.")
         }
 
-        for(i=0; i<dataStore.ODB.PPG.Cycles[cycleName].PPGCodes.length; i++){
+        for(i=0; i<dataStore.ODB.PPG.Cycles[cycleName].PPGcodes.length; i++){
         
             addNewCycleStep();
-            loadCycleStep(dataStore.cycle.stepIndex-1, dataStore.ODB.PPG.Cycles[cycleName].PPGCodes[i], dataStore.ODB.PPG.Cycles[cycleName].durations[i]);
+            loadCycleStep(dataStore.cycle.stepIndex-1, dataStore.ODB.PPG.Cycles[cycleName].PPGcodes[i], dataStore.ODB.PPG.Cycles[cycleName].durations[i]);
         }
 
         document.getElementById('cycleName').value = cycleName;
@@ -332,7 +332,7 @@
         // create requests to generate empty structure in odb to hold cycle definition
         dataStore.cycle.createCycleRequest = 'http://' + dataStore.host + '?cmd=jcreate&';
         for(i=0; i<cycleSteps.length; i++){
-            dataStore.cycle.createCycleRequest += 'odb' + (2*i) + '=/PPG/Cycles/' + cycleName + '/PPGCodes&type' + (2*i) + '=7&arraylen'+ (2*i) +'='+cycleSteps.length+'&';
+            dataStore.cycle.createCycleRequest += 'odb' + (2*i) + '=/PPG/Cycles/' + cycleName + '/PPGcodes&type' + (2*i) + '=7&arraylen'+ (2*i) +'='+cycleSteps.length+'&';
             dataStore.cycle.createCycleRequest += 'odb' + (2*i + 1) + '=/PPG/Cycles/' + cycleName + '/durations&type' + (2*i + 1) + '=7&arraylen' + (2*i + 1) + '=' + cycleSteps.length +'&';
         }
         dataStore.cycle.createCycleRequest += 'encoding=json&callback=populateCycle';
@@ -364,10 +364,10 @@
         // create the requests
         // different syntax to set one thing versus an array of things...
         if(cycleSteps.length == 1){
-            dataStore.cycle.setCycleStepRequests.push('http://' + dataStore.host + '?cmd=jset&odb=/PPG/Cycles/' + cycleName + '/PPGCodes&value=' + cycleStepCodes);
+            dataStore.cycle.setCycleStepRequests.push('http://' + dataStore.host + '?cmd=jset&odb=/PPG/Cycles/' + cycleName + '/PPGcodes&value=' + cycleStepCodes);
             dataStore.cycle.setCycleStepRequests.push('http://' + dataStore.host + '?cmd=jset&odb=/PPG/Cycles/' + cycleName + '/durations&value=' + cycleDurations);
         } else {
-            dataStore.cycle.setCycleStepRequests.push('http://' + dataStore.host + '?cmd=jset&odb=/PPG/Cycles/' + cycleName + '/PPGCodes[*]&value=' + cycleStepCodes);
+            dataStore.cycle.setCycleStepRequests.push('http://' + dataStore.host + '?cmd=jset&odb=/PPG/Cycles/' + cycleName + '/PPGcodes[*]&value=' + cycleStepCodes);
             dataStore.cycle.setCycleStepRequests.push('http://' + dataStore.host + '?cmd=jset&odb=/PPG/Cycles/' + cycleName + '/durations[*]&value=' + cycleDurations);
         }
 

--- a/templates/cycle-builder/cycle-builder.html
+++ b/templates/cycle-builder/cycle-builder.html
@@ -237,7 +237,6 @@
         }
 
         for(i=0; i<dataStore.ODB.PPG.Cycles[cycleName].PPGcodes.length; i++){
-        
             addNewCycleStep();
             loadCycleStep(dataStore.cycle.stepIndex-1, dataStore.ODB.PPG.Cycles[cycleName].PPGcodes[i], dataStore.ODB.PPG.Cycles[cycleName].durations[i]);
         }
@@ -272,14 +271,15 @@
         var i, j, keys, dur, durationUnit;
 
         //decide on a sensible unit for the duration
-        if(duration % 60000 == 0){
+
+        if(duration > 60000){
             dur = duration / 60000;
             durationUnit = 60000;
-        } else if(duration % 1000 == 0){
+        } else if(duration > 1000){
             dur = duration / 1000;
             durationUnit = 1000;
         } else {
-            dur = 1;
+            dur = duration;
             durationUnit = 1;
         }
 
@@ -415,16 +415,3 @@
         )      
     }
 </script>
-
-
-
-
-
-
-
-
-
-
-
-
-

--- a/templates/cycle-builder/cycle-builder.html
+++ b/templates/cycle-builder/cycle-builder.html
@@ -361,9 +361,6 @@
             cycleDurations += Math.floor(parseFloat(document.getElementById(stepIndex+'Duration').value, 10) * parseInt(selected(stepIndex+'DurationUnit') , 10))
         }
 
-        console.log(cycleDurations)
-        console.log(cycleStepCodes)
-
         // create the requests
         // different syntax to set one thing versus an array of things...
         if(cycleSteps.length == 1){

--- a/templates/cycle-builder/cycle-step.html
+++ b/templates/cycle-builder/cycle-step.html
@@ -20,7 +20,7 @@
     <ul id='cycle{{index}}RunControl'>
         {{#RunControl}}
             <li>
-                <input type='checkbox' id='{{index}}{{id}}' class='cycleOption' value={{code}}></input>
+                <input type='checkbox' id='{{index}}{{id}}' class='cycleOption' value={{code}} onchange='requestNewCycleName()'></input>
                 <label for='{{index}}{{id}}'>{{prettyName}}</label>
             </li>
         {{/RunControl}}
@@ -30,7 +30,7 @@
     <ul id='cycle{{index}}Trigger'>
         {{#Triggers}}
             <li>
-                <input type='checkbox' id='{{index}}{{id}}' class='cycleOption' value={{code}}></input>
+                <input type='checkbox' id='{{index}}{{id}}' class='cycleOption' value={{code}} onchange='requestNewCycleName()'></input>
                 <label for='{{index}}{{id}}'>{{prettyName}}</label>
             </li>
         {{/Triggers}}
@@ -40,7 +40,7 @@
     <ul id='cycle{{index}}DataCollection'>
         {{#DataCollection}}
             <li>
-                <input type='checkbox' id='{{index}}{{id}}' class='cycleOption' value={{code}}></input>
+                <input type='checkbox' id='{{index}}{{id}}' class='cycleOption' value={{code}} onchange='requestNewCycleName()'></input>
                 <label for='{{index}}{{id}}'>{{prettyName}}</label>
             </li>
         {{/DataCollection}}
@@ -50,7 +50,7 @@
     <ul id='cycle{{index}}Unassigned'>
         {{#Unassigned}}
             <li>
-                <input type='checkbox' id='{{index}}{{id}}' class='cycleOption' value={{code}}></input>
+                <input type='checkbox' id='{{index}}{{id}}' class='cycleOption' value={{code}} onchange='requestNewCycleName()'></input>
                 <label for='{{index}}{{id}}'>{{prettyName}}</label>
             </li>
         {{/Unassigned}}

--- a/templates/cycle-builder/cycle-step.html
+++ b/templates/cycle-builder/cycle-step.html
@@ -8,8 +8,8 @@
 
     <div id='{{index}}DurationControl'>
         <label for='{{index}}Duration'>Duration:</label>
-        <input id='{{index}}Duration' type='number' min='0' step='any' value='1' class='small-number'></input>
-        <select id='{{index}}DurationUnit' value='1'>
+        <input id='{{index}}Duration' type='number' min='0' step='any' value='1' class='small-number' onchange='requestNewCycleName()'></input>
+        <select id='{{index}}DurationUnit' value='1' onchange='requestNewCycleName()'>
             <option value='1'>ms</option>
             <option value='1000'>s</option>
             <option value='60000'>min</option>


### PR DESCRIPTION
Fixes #85, and:
- requests new cycle name when any parameter is changed
- updates docs
- adds 'Save and Apply' option to match filter page
- supports fractional time units (down to whole ms - so 1.5s == 1500 ms)
- begins to fix loading bug - `PPGCodes` was incorrectly capitalized in some places as `PPGcodes`. Before we merge, several of the existing patterns in the ODB have this incorrect capitalization and need to be changed - @SmithJK, will this break other stuff or can I just go ahead and change them?
